### PR TITLE
Fix Empty Guzzle Response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": ">=5.5.0",
         "snowio/php-async-soap": "~1.0",
         "snowio/soap-http-binding": "~0.2.0",
-        "guzzlehttp/guzzle": "^6.1"
+        "guzzlehttp/guzzle": "^6.1",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"

--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -59,10 +59,6 @@ class SoapClient implements SoapClientInterface
 
     private function interpretResponse(HttpBinding $httpBinding, ResponseInterface $response, $name, &$outputHeaders)
     {
-        try {
-            return $httpBinding->response($response, $name, $outputHeaders);
-        } finally {
-            $response->getBody()->close();
-        }
+        return $httpBinding->response($response, $name, $outputHeaders);
     }
 }

--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -63,9 +63,17 @@ class SoapClient implements SoapClientInterface
     private function tryLog(ResponseInterface $response, array $options = null)
     {
         if ($options && isset($options['logger']) && $options['logger'] instanceof LoggerInterface) {
+            $responseContents = $response->getBody()->__toString();
+
             $options['logger']->debug("Raw SOAP Response Received", [
-                'response' => $response->getBody()->__toString()
+                'response' => $responseContents
             ]);
+
+            if (empty($responseContents)) {
+                $options['logger']->warning("Empty response has been detected", [
+                    'response' => $responseContents
+                ]);
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

### Problem
So the main issue was that the response object returned by guzzle become empty by the second call with the client and we were all wondering why I first decided to add a var dump in order to show this issue and run the test `\Meng\AsyncSoap\Guzzle\SoapClientTest::resultsAreEquivalent` I put the following `var_dump` just after line https://github.com/meng-tian/async-soap-guzzle/blob/master/src/SoapClient.php#L44 

```php
//...
$response = (yield $this->client->sendAsync($request, $requestOptions));
var_dump($response->getBody()->__toString());
yield $this->interpretResponse($httpBinding, $response, $name, $outputHeaders);
//...
```

And I noticed that on the first call we end up with the desired `'body'` string only once consecutive calls were resulting in an empty string `''`. So in order to further expose the issue updated the test `\Meng\AsyncSoap\Guzzle\SoapClientTest::resultsAreEquivalent` such that instead of just returning the `SoapResult` string we instead return the body of the request (just to simplify what we put in we get out). This resulted in the failing test that exposed the issue.

### Fix

In order to fix this I went on to remove the finally block in the function call `SoapClient::interpretResponse` this was mainly cause the block will be called after the return and will effectively close the stream on the response body. This stream will be closed not just for the current response but all consecutive responses maybe because the stream is a resource in the location `php://temp` but once I removed that block it worked. Feel free to comment on what you think
